### PR TITLE
feat: add 21+ reusable field classes for settings pages

### DIFF
--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -29,6 +29,25 @@ final class FieldFactory
     {
         $this->fieldMap = [
             'text'        => Fields\TextField::class,
+            'email'       => Fields\EmailField::class,
+            'number'      => Fields\NumberField::class,
+            'password'    => Fields\PasswordField::class,
+            'url'         => Fields\UrlField::class,
+            'checkbox'    => Fields\CheckboxField::class,
+            'toggle'      => Fields\ToggleField::class,
+            'select'      => Fields\SelectField::class,
+            'multiselect' => Fields\MultiSelectField::class,
+            'radio'       => Fields\RadioField::class,
+            'buttongroup' => Fields\ButtonGroupField::class,
+            'textarea'    => Fields\TextareaField::class,
+            'code'        => Fields\CodeField::class,
+            'color'       => Fields\ColorField::class,
+            'date'        => Fields\DateField::class,
+            'datetime'    => Fields\DateTimeField::class,
+            'time'        => Fields\TimeField::class,
+            'range'       => Fields\RangeField::class,
+            'media'       => Fields\MediaField::class,
+            'description' => Fields\DescriptionField::class,
         ];
     }
 

--- a/src/Fields/AbstractField.php
+++ b/src/Fields/AbstractField.php
@@ -89,6 +89,11 @@ abstract class AbstractField implements FieldInterface
             return $this->config['default'];
         }
 
+        // Fallback for fields that might be arrays.
+        if (in_array(static::class, [MultiSelectField::class], true)) {
+            return [];
+        }
+
         return '';
     }
 }

--- a/src/Fields/ButtonGroupField.php
+++ b/src/Fields/ButtonGroupField.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Button Group Field Class
+ */
+final class ButtonGroupField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+
+        printf(
+            '<input type="hidden" name="%s" id="%s" value="%s" %s />',
+            esc_attr($this->config['name']),
+            esc_attr($this->config['id']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($attributes)
+        );
+
+        printf('<div class="%s-buttongroup-container">', esc_attr($htmlPrefix));
+
+        $options = $this->config['options'] ?? [];
+        foreach ($options as $optionValue => $optionLabel) {
+            $activeClass = ((string) $value === (string) $optionValue) ? ' active' : '';
+            printf(
+                '<button type="button" class="%s-buttongroup-option%s" data-value="%s">%s</button>',
+                esc_attr($htmlPrefix),
+                esc_attr($activeClass),
+                esc_attr((string) $optionValue),
+                esc_html($optionLabel)
+            );
+        }
+        echo '</div>';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        $allowedValues = array_keys($this->config['options'] ?? []);
+        if (in_array((string) $value, $allowedValues, true)) {
+            return (string) $value;
+        }
+        return '';
+    }
+}

--- a/src/Fields/CheckboxField.php
+++ b/src/Fields/CheckboxField.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Checkbox Field Class
+ */
+final class CheckboxField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        printf(
+            '<input type="checkbox" id="%s" name="%s" value="1" %s %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            checked($value, true, false),
+            $this->buildAttributesString($attributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): bool
+    {
+        return in_array($value, [true, 'true', 1, '1', 'on'], true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): bool
+    {
+        return (bool) ($this->config['default'] ?? false);
+    }
+}

--- a/src/Fields/CodeField.php
+++ b/src/Fields/CodeField.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Code Field Class
+ */
+final class CodeField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $language = $this->config['language'] ?? 'css';
+
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+
+        $defaultAttributes = [
+            'rows' => 10,
+            'cols' => 50,
+            'class' => "large-text {$htmlPrefix}-code-editor",
+            'data-language' => $language
+        ];
+
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<textarea id="%s" name="%s" %s>%s</textarea>',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            $this->buildAttributesString($mergedAttributes),
+            esc_textarea((string) $value)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        // Basic sanitization for code to preserve its structure.
+        return str_replace(["\x00", "\r\n", "\r"], ['', "\n", "\n"], (string) $value);
+    }
+}

--- a/src/Fields/ColorField.php
+++ b/src/Fields/ColorField.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Color Picker Field Class.
+ */
+final class ColorField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['class' => "{$htmlPrefix}-color-picker"];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<input type="text" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        $color = sanitize_hex_color((string) $value);
+        return $color ?? $this->getDefaultValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): string
+    {
+        return $this->config['default'] ?? '#000000';
+    }
+}

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Date Field Class
+ */
+final class DateField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['class' => "regular-text {$htmlPrefix}-flatpickr-date", 'readonly' => 'readonly'];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<input type="text" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/DateTimeField.php
+++ b/src/Fields/DateTimeField.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Renders a date and time picker field using the Flatpickr library.
+ */
+final class DateTimeField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['class' => "regular-text {$htmlPrefix}-flatpickr-datetime", 'readonly' => 'readonly'];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<input type="text" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/DescriptionField.php
+++ b/src/Fields/DescriptionField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Description Field Class
+ */
+final class DescriptionField extends AbstractField
+{
+    /**
+     * @{inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        // This field only displays its description, which is handled by the renderer.
+        // It has no input element.
+        if (!empty($this->config['description'])) {
+            echo '<div>' . wp_kses_post($this->config['description']) . '</div>';
+        }
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    public function sanitize(mixed $value): mixed
+    {
+        // No value to sanitize.
+        return null;
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    public function getDefaultValue(): mixed
+    {
+        return null;
+    }
+}

--- a/src/Fields/EmailField.php
+++ b/src/Fields/EmailField.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Email Field Class
+ */
+final class EmailField extends AbstractField
+{
+    /**
+     * @{inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = ['class' => 'regular-text'];
+
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<input type="email" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_email((string) $value);
+    }
+}

--- a/src/Fields/MediaField.php
+++ b/src/Fields/MediaField.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Media Field Class
+ */
+final class MediaField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $mediaUrl = '';
+        $mediaId = absint($value);
+        if ($mediaId > 0) {
+            $mediaUrl = wp_get_attachment_url($mediaId);
+        }
+
+        printf(
+            '<div class="%s-media-field-container">',
+            esc_attr($htmlPrefix)
+        );
+
+        printf(
+            '<input type="hidden" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($attributes)
+        );
+        printf(
+            '<button type="button" class="button %s-media-upload-button" data-field="%s">%s</button>',
+            esc_attr($htmlPrefix),
+            esc_attr($this->config['id']),
+            esc_html__('Select Media', 'default')
+        );
+
+        if (!empty($mediaUrl)) {
+            printf(
+                ' <button type="button" class="button %s-media-remove-button" data-field="%s">%s</button>',
+                esc_attr($htmlPrefix),
+                esc_attr($this->config['id']),
+                esc_html__('Remove', 'default')
+            );
+        }
+
+        printf('<div class="%s-media-preview">', esc_attr($htmlPrefix));
+        if (!empty($mediaUrl) && wp_attachment_is_image($mediaId)) {
+            printf(
+                '<img src="%s" alt="" style="max-width: 150px; height: auto; margin-top: 10px;" />',
+                esc_url($mediaUrl)
+            );
+        } elseif (!empty($mediaUrl)) {
+            $file = (string)get_attached_file($mediaId);
+            $fileName = ! empty($file) ? basename($file) : '';
+            printf('<p style="margin-top:10px;"><strong>File:</strong> %s</p>', esc_html($fileName));
+        }
+        echo '</div></div>';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): int
+    {
+        return absint($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): int
+    {
+        return (int) ($this->config['default'] ?? 0);
+    }
+}

--- a/src/Fields/MultiSelectField.php
+++ b/src/Fields/MultiSelectField.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Multi Select Field
+ */
+final class MultiSelectField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['multiple' => 'multiple', 'class' => "{$htmlPrefix}-select2-field"];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+        $selectedValues = is_array($value) ? array_map('strval', $value) : [];
+
+        printf(
+            '<select id="%s" name="%s[]" %s>',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            $this->buildAttributesString($mergedAttributes)
+        );
+
+        $options = $this->config['options'] ?? [];
+        foreach ($options as $optionValue => $optionLabel) {
+            $selected = in_array((string) $optionValue, $selectedValues, true) ? 'selected="selected"' : '';
+            printf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr((string) $optionValue),
+                $selected,
+                esc_html($optionLabel)
+            );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array<int, string>
+     */
+    public function sanitize(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $allowedValues = array_keys($this->config['options'] ?? []);
+        $sanitized = [];
+        foreach ($value as $item) {
+            if (in_array((string) $item, $allowedValues, true)) {
+                $sanitized[] = (string) $item;
+            }
+        }
+        return $sanitized;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array<int, string>
+     */
+    public function getDefaultValue(): array
+    {
+        return $this->config['default'] ?? [];
+    }
+}

--- a/src/Fields/NumberField.php
+++ b/src/Fields/NumberField.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Number Field Class
+ */
+final class NumberField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = ['class' => 'regular-text'];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+        printf(
+            '<input type="number" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): int|float
+    {
+        if (!is_numeric($value)) {
+            return 0;
+        }
+        $numericValue = $value + 0; // Cast to number
+        return is_float($numericValue) ? (float) $value : (int) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): int
+    {
+        return (int) ($this->config['default'] ?? 0);
+    }
+}

--- a/src/Fields/PasswordField.php
+++ b/src/Fields/PasswordField.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Password Field Class
+ */
+final class PasswordField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = ['class' => 'regular-text'];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+        printf(
+            '<input type="password" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        // Passwords should not be altered during sanitization beyond
+        // basic string conversion.
+        return (string) $value;
+    }
+}

--- a/src/Fields/RadioField.php
+++ b/src/Fields/RadioField.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Radio Field Class
+ */
+final class RadioField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $options = $this->config['options'] ?? [];
+        foreach ($options as $optionValue => $optionLabel) {
+            $radioId = $this->config['id'] . '_' . $optionValue;
+
+            printf(
+                '<label for="%s">
+                           <input type="radio" id="%s" name="%s" value="%s" %s %s />
+                           %s
+                       </label><br />',
+                esc_attr($radioId),
+                esc_attr($radioId),
+                esc_attr($this->config['name']),
+                esc_attr((string) $optionValue),
+                checked((string) $value, (string) $optionValue, false),
+                $this->buildAttributesString($attributes),
+                esc_html($optionLabel)
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        $allowedValues = array_keys($this->config['options'] ?? []);
+        if (in_array((string) $value, $allowedValues, true)) {
+            return (string) $value;
+        }
+        return '';
+    }
+}

--- a/src/Fields/RangeField.php
+++ b/src/Fields/RangeField.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Range Field Class
+ */
+final class RangeField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['min' => 0, 'max' => 100, 'step' => 1, 'class' => "{$htmlPrefix}-enhanced-range-slider"];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+        $min = (int) ($mergedAttributes['min'] ?? 0);
+        $max = (int) ($mergedAttributes['max'] ?? 100);
+        $currentValue = $value ?? $min;
+
+        printf('<div class="%s-enhanced-range-container">', esc_attr($htmlPrefix));
+        printf(
+            '<input type="range" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $currentValue),
+            $this->buildAttributesString($mergedAttributes)
+        );
+        printf(
+            '<input type="number" class="%s-range-value-input" value="%s" min="%d" max="%d" readonly />',
+            esc_attr($htmlPrefix),
+            esc_attr((string) $currentValue),
+            $min,
+            $max
+        );
+        echo '</div>';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): int|float
+    {
+        if (!is_numeric($value)) {
+            return 0;
+        }
+        $numericValue = $value + 0;
+        return is_float($numericValue) ? (float) $value : (int) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): int
+    {
+        return (int) ($this->config['default'] ?? 0);
+    }
+}

--- a/src/Fields/SelectField.php
+++ b/src/Fields/SelectField.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Select Field Class
+ */
+final class SelectField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+        $defaultAttributes = ['class' => "{$htmlPrefix}-select2-field"];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<select id="%s" name="%s" %s>',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            $this->buildAttributesString($mergedAttributes)
+        );
+
+        $options = $this->config['options'] ?? [];
+        foreach ($options as $optionValue => $optionLabel) {
+            printf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr((string) $optionValue),
+                selected((string) $value, (string) $optionValue, false),
+                esc_html($optionLabel)
+            );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        $allowedValues = array_keys($this->config['options'] ?? []);
+        if (in_array((string) $value, $allowedValues, true)) {
+            return (string) $value;
+        }
+        return '';
+    }
+}

--- a/src/Fields/TextareaField.php
+++ b/src/Fields/TextareaField.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Textarea Field Class
+ */
+final class TextareaField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = ['rows' => 5, 'cols' => 50, 'class' => 'large-text'];
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+        printf(
+            '<textarea id="%s" name="%s" %s>%s</textarea>',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            $this->buildAttributesString($mergedAttributes),
+            esc_textarea((string) $value)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_textarea_field((string) $value);
+    }
+}

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Time Field Class
+ */
+final class TimeField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = [
+            'class' => 'regular-text flatpickr-time',
+            'readonly' => 'readonly'
+        ];
+
+        $mergedAttributes = array_merge($defaultAttributes, $attributes);
+
+        printf(
+            '<input type="text" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_text_field((string) $value);
+    }
+}

--- a/src/Fields/ToggleField.php
+++ b/src/Fields/ToggleField.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * Toggle Field Class
+ */
+final class ToggleField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $htmlPrefix = $this->config['htmlPrefix'] ?? 'wptechnix-settings';
+
+        printf(
+            '<label class="%s-toggle">
+				<input type="checkbox" id="%s" name="%s" value="1" %s %s />
+				<span class="%s-toggle-slider"></span>
+			</label>',
+            esc_attr($htmlPrefix),
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            checked($value, true, false),
+            $this->buildAttributesString($attributes),
+            esc_attr($htmlPrefix)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): bool
+    {
+        return in_array($value, [true, 'true', 1, '1', 'on'], true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultValue(): bool
+    {
+        return (bool) ($this->config['default'] ?? false);
+    }
+}

--- a/src/Fields/UrlField.php
+++ b/src/Fields/UrlField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPTechnix\WPSettings\Fields;
+
+/**
+ * URL Field Class
+ */
+final class UrlField extends AbstractField
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function render(mixed $value, array $attributes): void
+    {
+        $defaultAttributes = ['class' => 'regular-text'];
+
+        $mergedAttributes = array_merge(
+            $defaultAttributes,
+            $attributes
+        );
+
+        printf(
+            '<input type="url" id="%s" name="%s" value="%s" %s />',
+            esc_attr($this->config['id']),
+            esc_attr($this->config['name']),
+            esc_attr((string) $value),
+            $this->buildAttributesString($mergedAttributes)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sanitize(mixed $value): string
+    {
+        return esc_url_raw((string) $value);
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces a set of 21+ reusable field classes for building settings pages.
### Text & Input Fields

* `TextField.php`
* `TextareaField.php`
* `NumberField.php`
* `PasswordField.php`
* `EmailField.php`
* `UrlField.php`
* `CodeField.php`
* `DescriptionField.php`

### Choice & Selection Fields

* `SelectField.php`
* `MultiSelectField.php`
* `RadioField.php`
* `CheckboxField.php`
* `ButtonGroupField.php`
* `ToggleField.php`

### Date & Time Fields

* `DateField.php`
* `TimeField.php`
* `DateTimeField.php`

### Media & Color Fields

* `MediaField.php`
* `ColorField.php`

### Range & Slider Fields

* `RangeField.php`
